### PR TITLE
Sort As Lists of Int

### DIFF
--- a/visualization/main.py
+++ b/visualization/main.py
@@ -42,7 +42,7 @@ def read_data(tool: str):
             graph_data[metric].append((tag_number, value))
 
     for _, v in graph_data.items():
-        v.sort()
+        v.sort(key=lambda t: list(map(int, t[0].split("-")[1].split("."))))
     return graph_data
 
 


### PR DESCRIPTION
Convert tags to a list of integers by splitting them on ".", then sort these lists. This will ensure that the major tag number (first element of the list) order is respected beforee any minor tag numbers.