### PR TITLE
Use builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,21 @@ It consists of four components:
 
 1. A bash script that transforms a local git repository into a folder per tag of that git repository
 2. A python program that will run [modu](https://github.com/parameterIT/tool/) on each sub-directory of a given directory (this will be paired with script (1))
-3. A python program that runs code climate on each sub-directory of a given directory (this will be paired with script (1))
+3. A python program that will run code climate on each tag of a git repository
 4. A python program that compares the results of (2) and (3) visually on line graphs
 
 ## Requirements
 
 - Many of the provided scripts and programs make use of your local installation of _git_, so make that it is set-up and available in your PATH.
+- The scripts also use SSH to interact with GitHub through git, you should [generate SSH keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) and [add them to GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
 - Component (2) requires a local installation of _modu_. The project's [README](https://github.com/parameterIT/tool/blob/main/README.md) describes how to set it up
 - To visualize the results we use [_Bokeh_](https://docs.bokeh.org/en/latest/index.html), which requires [additional set-up](https://docs.bokeh.org/en/latest/docs/user_guide/output/export.html) for exporting the graphs to PNG files
-- It requires that you have push access to and a local copy of [parameterIT's testing repository](https://github.com/parameterIT/testing)
 
 ## Running
 
 ### Preparing the Data
+
+#### For _modu_ 
 
 First it will be necessary to transform a git repository into a series of folders each containing that git repository's contents at a specific version.
 The following command (from the `experiment-toolkit` folder) executes a bash script which automates this process:
@@ -53,6 +55,20 @@ flask-tags
   \_ flask-0.12
   \_ ...
 ```
+
+#### For Code Climate
+
+You will need a Code Climate account.
+Once you have a Code Climate account create a git repository for Code Climate to analyze on GitHub.
+The contents of this git repository will updated automatically by program (3).
+
+Clone your git repository, for example in parameterIT we used the _parameterIT/testing_ repository:
+
+```sh
+git clone git@github.com:parameterIT/testing.git
+```
+
+Next you should log-in to your Code Climate account and add the git repository you just cloned to Code Climate.
 
 ### Executing _modu_
 
@@ -121,7 +137,7 @@ Remember to save the file.
 Now, run the Code Climate tool by using the following command. NOTE: github-slug is in the format `username/repository-name`:
 
 ```sh
-./run.sh <path to local copy of repository> <github-slug of the remote of the repo> <path to testing repository>
+./run.sh <path to local copy of repository> <github-slug of the remote of the repo> <path to testing repository> <github slug of the remote of the testing repo>
 ```
 
 For example with the directory structure:
@@ -137,7 +153,7 @@ testing
 
 You can run the command:
 ```sh
-./run.sh ../../flask pallets/flask ../../testing
+./run.sh ../../flask pallets/flask ../../testing parameterIT/testing
 ```
 
 This will produce .csv files that match the format of _modu_ using results gathered through code climate in the `experiment-toolkit/run-code-climate-on-tags/output` folder.

--- a/run-code-climate-on-tags/code_climate.py
+++ b/run-code-climate-on-tags/code_climate.py
@@ -184,3 +184,22 @@ class Client:
                 has_next = False
 
         return builds
+
+    def get_build_page(self, repo_id: str, page: int) -> List[BetterBuild]:
+        target = f"{_BASE_CODE_CLIMATE_URL}repos/{repo_id}/builds?page[number]={[page]}&page[size]=100"
+        builds = []
+        resp = self.session.get(target)
+        json_resp = resp.json()
+
+        for b in json_resp["data"]:
+            id = b["id"]
+            state = b["attributes"]["state"]
+            commit_sha = b["attributes"]["commit_sha"]
+            snapshot_id = None
+            if state == "complete":
+                snapshot_id = b["relationships"]["snapshot"]["data"]["id"]
+
+            build = BetterBuild(id, repo_id, state, commit_sha, snapshot_id)
+            builds.append(build)
+
+        return builds

--- a/run-code-climate-on-tags/code_climate.py
+++ b/run-code-climate-on-tags/code_climate.py
@@ -186,7 +186,7 @@ class Client:
         return builds
 
     def get_build_page(self, repo_id: str, page: int) -> List[BetterBuild]:
-        target = f"{_BASE_CODE_CLIMATE_URL}repos/{repo_id}/builds?page[number]={[page]}&page[size]=100"
+        target = f"{_BASE_CODE_CLIMATE_URL}repos/{repo_id}/builds?page[number]={page}&page[size]=100"
         builds = []
         resp = self.session.get(target)
         json_resp = resp.json()

--- a/run-code-climate-on-tags/git.py
+++ b/run-code-climate-on-tags/git.py
@@ -28,7 +28,7 @@ def switch_repo(testing_repo: Path, github_slug: str):
 
 def reset_repo(testing_repo: Path, commit: str):
     subprocess.run([f"cd {testing_repo} && git reset --hard {commit}"], shell=True)
-    subprocess.run([f"cd {testing_repo} && git push -f"], shell=True)
+    subprocess.run([f"cd {testing_repo} && git push origin -f"], shell=True)
 
 
 def iterate_over_tags(tags: List, action_between_tags: Callable, testing_repo: Path):

--- a/run-code-climate-on-tags/main.py
+++ b/run-code-climate-on-tags/main.py
@@ -10,11 +10,9 @@ import code_climate
 from pathlib import Path
 from typing import Dict, List
 
-USAGE_STRING = "Usage: main.py <Local Copy of Repository to Analyze> <GITHUB_SLUG> <Testing Repo>\nwhere GITHUB_SLUG is in the format 'username/reponame' on GitHub"
+USAGE_STRING = "Usage: main.py <Local Copy of Repository to Analyze> <GITHUB_SLUG_OF_REPO_TO_ANALYZE> <Testing Repo> <REMOTE_TESTING_REPO> \nwhere GITHUB_SLUG is in the format 'username/reponame' on GitHub"
 
 ACCESS_TOKEN = os.getenv("CODE_CLIMATE_TOKEN")
-CODE_CLIMATE_REPO = "parameterIT/testing"
-
 
 def main():
     logging.basicConfig(level=logging.INFO)
@@ -23,7 +21,7 @@ def main():
         logging.error("CODE_CLIMATE_TOKEN environment variable must be set")
         exit(1)
 
-    if len(sys.argv) != 4:
+    if len(sys.argv) != 5:
         logging.error("Incorrect number of arguments supplied")
         print(USAGE_STRING)
         exit(1)
@@ -40,11 +38,15 @@ def main():
         print(USAGE_STRING)
 
     github_slug = sys.argv[2]
+    testing_github_slug = sys.argv[4]
+
+    git.switch_repo(testing_repo, github_slug)
 
     tag_to_commit = git.tag_to_commit_mapping(target_dir)
 
     client: code_climate.Client = code_climate.Client(ACCESS_TOKEN)
-    repo_id = client.get_id_for_repo("parameterIT/testing")
+    repo_id = client.get_id_for_repo(testing_github_slug)
+    logging.info(f"Id for {testing_github_slug} is {repo_id}")
     builds = client.get_builds(repo_id)
 
     commits_with_no_builds = list(tag_to_commit.values())
@@ -62,9 +64,11 @@ def main():
         # Get the first page of builds and see if it contains the commit sha, otherwise wait 10 seconds and try again
         is_build_complete = False
         while not is_build_complete:
+            logging.info("Sleeping for 10 seconds...")
             time.sleep(10)
             builds = client.get_build_page(repo_id, 1)
             for build in builds:
+                logging.info(f"Looking at build {build.id} for {build.commit_sha} with state {build.state}")
                 if build.commit_sha == commit and build.state == "complete":
                     is_build_complete = True
 

--- a/run-code-climate-on-tags/main.py
+++ b/run-code-climate-on-tags/main.py
@@ -66,6 +66,7 @@ def main():
         while not is_build_complete:
             logging.info("Sleeping for 10 seconds...")
             time.sleep(10)
+            # Builds are in chronological order, so newest one should be on the first page
             builds = client.get_build_page(repo_id, 1)
             for build in builds:
                 logging.info(f"Looking at build {build.id} for {build.commit_sha} with state {build.state}")


### PR DESCRIPTION
Changed data collection for Code Climate to rely on builds. Will only make pushes to a repository to invoke a build when a commit sha is missing from the builds on Code Climate.

These changes also remove the coupling to parameterIT/testing making it possible for users outside of parameterIT to use the tool.